### PR TITLE
The BasePlus package [ver. 1.33.0]

### DIFF
--- a/baseplus.md
+++ b/baseplus.md
@@ -45,7 +45,7 @@
   * [`%RainCloudPlot()` macro](#raincloudplot-macro)
   * [`%zipLibrary()` macro](#ziplibrary-macro)
   * [`%unzipLibrary()` macro](#unziplibrary-macro)
-  * [`%unzipArch()` macro](#unzipatch-macro)
+  * [`%unzipArch()` macro](#unziparch-macro)
   * [`%LDSN()` macro](#ldsn-macro)
   * [`%LDsNm()` macro](#ldsnm-macro)
   * [`%LVarNm()` macro](#lvarnm-macro)


### PR DESCRIPTION
## The BasePlus package [ver. 1.33.0]

- New macro [`%unzipArch()`](https://github.com/SASPAC/baseplus/blob/main/baseplus.md#unziparch-macro) added. The macro allows to extract ZIP archive file from SAS session and does not need `XCMD` (is OS independent).
- Documentation updated.

---